### PR TITLE
Updating keras dependencies to tf.keras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ lightkurve >= 1.7.0
 scikit-learn == 0.23
 Bottleneck == 1.3.2
 requests
-setuptools >= 41.0.0 # Required by tensorflow 1.15
-tensorflow == 2.3.0
+setuptools >= 41.0.0
+tensorflow == 2.3.1
 Pillow
 xgboost == 0.90
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,7 @@ scikit-learn == 0.23
 Bottleneck == 1.3.2
 requests
 setuptools >= 41.0.0 # Required by tensorflow 1.15
-tensorflow == 1.15.4
-keras == 2.3.1
+tensorflow == 2.3.0
 Pillow
 xgboost == 0.90
 tqdm

--- a/starclass/SLOSH/SLOSH.py
+++ b/starclass/SLOSH/SLOSH.py
@@ -10,7 +10,7 @@ The SLOSH method for detecting solar-like oscillations (2D deep learning methods
 import numpy as np
 import os
 import logging
-import tensorflow as tf
+import tensorflow
 from sklearn.metrics import classification_report
 
 from . import SLOSH_prepro as preprocessing
@@ -43,7 +43,7 @@ class SLOSHClassifier(BaseClassifier):
 
 		# Set the global random seeds:
 		np.random.seed(self.random_seed)
-		tf.random.set_seed(self.random_seed)
+		tensorflow.random.set_seed(self.random_seed)
 
 		# Find model file
 		if clfile is not None:
@@ -55,8 +55,8 @@ class SLOSHClassifier(BaseClassifier):
 			logger.info("Loading pre-trained model...")
 			# load pre-trained classifier
 			self.predictable = True
-			tf.keras.backend.set_learning_phase(1)
-			self.classifier_list.append(tf.keras.models.load_model(self.model_file))
+			tensorflow.keras.backend.set_learning_phase(1)
+			self.classifier_list.append(tensorflow.keras.models.load_model(self.model_file))
 		else:
 			logger.info('No saved models provided. Predict functions are disabled.')
 			self.predictable = False
@@ -155,9 +155,9 @@ class SLOSHClassifier(BaseClassifier):
 		else:
 			logger.info('Train Images exist...')
 
-		reduce_lr = tf.keras.callbacks.ReduceLROnPlateau(factor=0.5, patience=5, verbose=1)
-		early_stop = tf.keras.callbacks.EarlyStopping(monitor='val_loss', patience=10, restore_best_weights=True)
-		checkpoint = tf.keras.callbacks.ModelCheckpoint(self.model_file,
+		reduce_lr = tensorflow.keras.callbacks.ReduceLROnPlateau(factor=0.5, patience=5, verbose=1)
+		early_stop = tensorflow.keras.callbacks.EarlyStopping(monitor='val_loss', patience=10, restore_best_weights=True)
+		checkpoint = tensorflow.keras.callbacks.ModelCheckpoint(self.model_file,
 			monitor='val_loss', verbose=1, save_best_only=True)
 
 		#model = None
@@ -210,8 +210,8 @@ class SLOSHClassifier(BaseClassifier):
 		:param infile: Path to trained model
 		:return: None
 		'''
-		tf.keras.backend.set_learning_phase(1)
-		self.classifier_list.append(tf.keras.models.load_model(infile))
+		tensorflow.keras.backend.set_learning_phase(1)
+		self.classifier_list.append(tensorflow.keras.models.load_model(infile))
 		self.predictable = True
 
 	#----------------------------------------------------------------------------------------------
@@ -224,7 +224,7 @@ class SLOSHClassifier(BaseClassifier):
 		self.predictable = False
 
 #--------------------------------------------------------------------------------------------------
-class TestCallback(tf.keras.callbacks.Callback):
+class TestCallback(tensorflow.keras.callbacks.Callback):
 
 	def __init__(self, val_data):
 		self.validation_data = val_data

--- a/starclass/SLOSH/SLOSH.py
+++ b/starclass/SLOSH/SLOSH.py
@@ -7,13 +7,9 @@ The SLOSH method for detecting solar-like oscillations (2D deep learning methods
 .. codeauthor:: James Kuszlewicz <kuszlewicz@mps.mpg.de>
 """
 
-import keras
 import numpy as np
 import os
 import logging
-from keras import backend as K
-from keras.models import load_model
-from keras.callbacks import ReduceLROnPlateau, EarlyStopping, ModelCheckpoint
 import tensorflow as tf
 from sklearn.metrics import classification_report
 
@@ -47,7 +43,7 @@ class SLOSHClassifier(BaseClassifier):
 
 		# Set the global random seeds:
 		np.random.seed(self.random_seed)
-		tf.compat.v1.set_random_seed(self.random_seed)
+		tf.random.set_seed(self.random_seed)
 
 		# Find model file
 		if clfile is not None:
@@ -59,8 +55,8 @@ class SLOSHClassifier(BaseClassifier):
 			logger.info("Loading pre-trained model...")
 			# load pre-trained classifier
 			self.predictable = True
-			K.set_learning_phase(1)
-			self.classifier_list.append(load_model(self.model_file))
+			tf.keras.backend.set_learning_phase(1)
+			self.classifier_list.append(tf.keras.models.load_model(self.model_file))
 		else:
 			logger.info('No saved models provided. Predict functions are disabled.')
 			self.predictable = False
@@ -159,9 +155,9 @@ class SLOSHClassifier(BaseClassifier):
 		else:
 			logger.info('Train Images exist...')
 
-		reduce_lr = ReduceLROnPlateau(factor=0.5, patience=5, verbose=1)
-		early_stop = EarlyStopping(monitor='val_loss', patience=10, restore_best_weights=True)
-		checkpoint = ModelCheckpoint(self.model_file,
+		reduce_lr = tf.keras.callbacks.ReduceLROnPlateau(factor=0.5, patience=5, verbose=1)
+		early_stop = tf.keras.callbacks.EarlyStopping(monitor='val_loss', patience=10, restore_best_weights=True)
+		checkpoint = tf.keras.callbacks.ModelCheckpoint(self.model_file,
 			monitor='val_loss', verbose=1, save_best_only=True)
 
 		#model = None
@@ -214,8 +210,8 @@ class SLOSHClassifier(BaseClassifier):
 		:param infile: Path to trained model
 		:return: None
 		'''
-		K.set_learning_phase(1)
-		self.classifier_list.append(load_model(infile))
+		tf.keras.backend.set_learning_phase(1)
+		self.classifier_list.append(tf.keras.models.load_model(infile))
 		self.predictable = True
 
 	#----------------------------------------------------------------------------------------------
@@ -228,7 +224,7 @@ class SLOSHClassifier(BaseClassifier):
 		self.predictable = False
 
 #--------------------------------------------------------------------------------------------------
-class TestCallback(keras.callbacks.Callback):
+class TestCallback(tf.keras.callbacks.Callback):
 
 	def __init__(self, val_data):
 		self.validation_data = val_data

--- a/starclass/SLOSH/SLOSH_prepro.py
+++ b/starclass/SLOSH/SLOSH_prepro.py
@@ -9,7 +9,7 @@ Utilities for SLOSH (2D deep learning methods).
 import os
 import numpy as np
 import tensorflow as tf
-from tf.keras.layers import InputLayer, Dropout, MaxPool2D, Flatten, Conv2D, LeakyReLU, Dense
+from tf.keras.layers import Dropout, MaxPool2D, Flatten, Conv2D, LeakyReLU, Dense
 from tf.keras.regularizers import l2
 from tf.keras.optimizers import Adam
 from scipy.stats import binned_statistic
@@ -261,7 +261,7 @@ def default_classifier_model():
 	'''
 	reg = l2(7.5E-4)
 	adam = Adam(clipnorm=1.)
-	input1 = InputLayer(input_shape=(128, 128, 1))
+	input1 = tf.keras.Input(shape=(128, 128, 1))
 	drop0 = Dropout(0.5)(input1)
 	conv1 = Conv2D(4, kernel_size=(7, 7), padding='same', kernel_initializer='glorot_uniform',
 		kernel_regularizer=reg)(drop0)
@@ -292,7 +292,7 @@ def default_regressor_model():
 	:return: model: untrained regressor model
 	'''
 	reg = l2(7.5E-4)
-	input1 = InputLayer(input_shape=(128, 128, 1))
+	input1 = tf.keras.Input(shape=(128, 128, 1))
 	drop0 = Dropout(0.25)(input1)
 	conv1 = Conv2D(4, kernel_size=(5, 5), padding='same', kernel_initializer='glorot_uniform',
 		kernel_regularizer=reg)(drop0)

--- a/starclass/SLOSH/SLOSH_prepro.py
+++ b/starclass/SLOSH/SLOSH_prepro.py
@@ -8,7 +8,7 @@ Utilities for SLOSH (2D deep learning methods).
 
 import os
 import numpy as np
-import tensorflow as tf
+import tensorflow
 from tf.keras.layers import Dropout, MaxPool2D, Flatten, Conv2D, LeakyReLU, Dense
 from tf.keras.regularizers import l2
 from tf.keras.optimizers import Adam
@@ -18,7 +18,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils import shuffle as sklearn_shuffle
 
 #--------------------------------------------------------------------------------------------------
-class npy_generator(tf.keras.utils.Sequence):
+class npy_generator(tensorflow.keras.utils.Sequence):
 	"""
 	Generator that loads numpy arrays from a folder for training a deep learning model. This version has been tailored
 	for a classifier, with #the training labels taken from the subfolder. Indices of training/validation can be passed
@@ -75,7 +75,7 @@ class npy_generator(tf.keras.utils.Sequence):
 		batch_labels = [self.subfolder_labels[k] for k in batch_indices]
 		# Generate data
 		X, y = self.__data_generation(batch_filenames, batch_labels)
-		return X, tf.keras.utils.to_categorical(y, num_classes=8)
+		return X, tensorflow.keras.utils.to_categorical(y, num_classes=8)
 
 	#----------------------------------------------------------------------------------------------
 	def on_epoch_end(self):
@@ -259,7 +259,7 @@ def default_classifier_model():
 	'''
 	reg = l2(2.5E-3)
 	adam = Adam(clipnorm=1.)
-	input1 = tf.keras.Input(shape=(128, 128, 1))
+	input1 = tensorflow.keras.Input(shape=(128, 128, 1))
 	drop0 = Dropout(0.5)(input1)
 	conv1 = Conv2D(4, kernel_size=(7, 7), padding='same', kernel_initializer='glorot_uniform',
 		kernel_regularizer=reg)(drop0)
@@ -278,7 +278,7 @@ def default_classifier_model():
 	drop1 = Dropout(0.5)(flat)
 	dense1 = Dense(128, kernel_initializer='glorot_uniform', activation='relu', kernel_regularizer=reg)(drop1)
 	output = Dense(8, kernel_initializer='glorot_uniform', activation='softmax')(dense1)
-	model = tf.keras.Model(input1, output)
+	model = tensorflow.keras.Model(input1, output)
 
 	model.compile(optimizer=adam, loss='categorical_crossentropy', metrics=['accuracy'])
 	return model
@@ -290,7 +290,7 @@ def default_regressor_model():
 	:return: model: untrained regressor model
 	'''
 	reg = l2(7.5E-4)
-	input1 = tf.keras.Input(shape=(128, 128, 1))
+	input1 = tensorflow.keras.Input(shape=(128, 128, 1))
 	drop0 = Dropout(0.25)(input1)
 	conv1 = Conv2D(4, kernel_size=(5, 5), padding='same', kernel_initializer='glorot_uniform',
 		kernel_regularizer=reg)(drop0)
@@ -310,7 +310,7 @@ def default_regressor_model():
 	dense1 = Dense(1024, kernel_initializer='glorot_uniform', activation='relu', kernel_regularizer=reg)(drop1)
 	dense2 = Dense(128, kernel_regularizer=reg, kernel_initializer='glorot_uniform', activation='relu')(dense1)
 	output = Dense(1, kernel_initializer='glorot_uniform')(dense2)
-	model = tf.keras.Model(input1, output)
+	model = tensorflow.keras.Model(input1, output)
 
 	model.compile(optimizer='Nadam', loss=weighted_mean_squared_error, metrics=['mae'])
 	return model

--- a/starclass/SLOSH/SLOSH_prepro.py
+++ b/starclass/SLOSH/SLOSH_prepro.py
@@ -259,7 +259,7 @@ def default_classifier_model():
 	Default classifier model architecture
 	:return: model: untrained classifier model
 	'''
-	reg = l2(7.5E-4)
+	reg = l2(2.5E-3)
 	adam = Adam(clipnorm=1.)
 	input1 = tf.keras.Input(shape=(128, 128, 1))
 	drop0 = Dropout(0.5)(input1)

--- a/starclass/SLOSH/SLOSH_prepro.py
+++ b/starclass/SLOSH/SLOSH_prepro.py
@@ -9,9 +9,9 @@ Utilities for SLOSH (2D deep learning methods).
 import os
 import numpy as np
 import tensorflow
-from tf.keras.layers import Dropout, MaxPool2D, Flatten, Conv2D, LeakyReLU, Dense
-from tf.keras.regularizers import l2
-from tf.keras.optimizers import Adam
+from tensorflow.keras.layers import Dropout, MaxPool2D, Flatten, Conv2D, LeakyReLU, Dense
+from tensorflow.keras.regularizers import l2
+from tensorflow.keras.optimizers import Adam
 from scipy.stats import binned_statistic
 from scipy.interpolate import interp1d
 from sklearn.model_selection import train_test_split


### PR DESCRIPTION
The explicit dependencies on keras have been replaced in favour of tf.keras, which supports Tensorflow 2. The regularization parameter for training SLOSH has been updated in accordance the testing done by @jsk389.