### PR TITLE
Create "fake" todo-files

### DIFF
--- a/run_create_todolist.py
+++ b/run_create_todolist.py
@@ -12,10 +12,10 @@ if __name__ == '__main__':
 	parser = argparse.ArgumentParser(description='')
 	parser.add_argument('-d', '--debug', help='Print debug messages.', action='store_true')
 	parser.add_argument('-q', '--quiet', help='Only report warnings and errors.', action='store_true')
-	parser.add_argument('-o', '--overwrite', action='store_true')
-	parser.add_argument('--pattern', type=str, default=None)
-	parser.add_argument('--output', type=str, default='todo.sqlite')
-	parser.add_argument('input_folder', type=str)
+	parser.add_argument('-o', '--overwrite', help='Overwrite existing todo-file.', action='store_true')
+	parser.add_argument('--pattern', type=str, default=None, help='File pattern to search for light curves with.')
+	parser.add_argument('--name', type=str, default='todo.sqlite', help='Name of todo-file to create.')
+	parser.add_argument('input_folder', type=str, help='Directory containing light curves to build todo-file from.')
 	args = parser.parse_args()
 
 	# Set logging level:
@@ -38,6 +38,6 @@ if __name__ == '__main__':
 
 	# Download all data:
 	starclass.todolist.create_fake_todolist(args.input_folder,
-		output_todo=args.output,
-		file_pattern=args.pattern,
+		name=args.name,
+		pattern=args.pattern,
 		overwrite=args.overwrite)

--- a/run_create_todolist.py
+++ b/run_create_todolist.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import logging
+import starclass
+
+#--------------------------------------------------------------------------------------------------
+if __name__ == '__main__':
+
+	# Parse command line arguments:
+	parser = argparse.ArgumentParser(description='')
+	parser.add_argument('-d', '--debug', help='Print debug messages.', action='store_true')
+	parser.add_argument('-q', '--quiet', help='Only report warnings and errors.', action='store_true')
+	parser.add_argument('-o', '--overwrite', action='store_true')
+	parser.add_argument('--pattern', type=str, default=None)
+	parser.add_argument('--output', type=str, default='todo.sqlite')
+	parser.add_argument('input_folder', type=str)
+	args = parser.parse_args()
+
+	# Set logging level:
+	logging_level = logging.INFO
+	if args.quiet:
+		logging_level = logging.WARNING
+	elif args.debug:
+		logging_level = logging.DEBUG
+
+	# Setup logging:
+	formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+	console = logging.StreamHandler()
+	console.setFormatter(formatter)
+	logger = logging.getLogger(__name__)
+	logger.addHandler(console)
+	logger.setLevel(logging_level)
+	logger_parent = logging.getLogger('starclass')
+	logger_parent.addHandler(console)
+	logger_parent.setLevel(logging_level)
+
+	# Download all data:
+	starclass.todolist.create_fake_todolist(args.input_folder,
+		output_todo=args.output,
+		file_pattern=args.pattern,
+		overwrite=args.overwrite)

--- a/run_starclass.py
+++ b/run_starclass.py
@@ -26,6 +26,11 @@ def main():
 	parser.add_argument('-l', '--level', help='Classification level', default='L1', choices=('L1', 'L2'))
 	#parser.add_argument('--datalevel', help="", default='corr', choices=('raw', 'corr')) # TODO: Come up with better name than "datalevel"?
 	#parser.add_argument('--starid', type=int, help='TIC identifier of target.', nargs='?', default=None)
+	# Lightcurve truncate override switch:
+	group = parser.add_mutually_exclusive_group(required=False)
+	group.add_argument('--truncate', dest='truncate', action='store_true', help='Force light curve truncation.')
+	group.add_argument('--no-truncate', dest='truncate', action='store_false', help='Force no light curve truncation.')
+	parser.set_defaults(truncate=None)
 	parser.add_argument('input_folder', type=str, help='Input directory to run classification on.', nargs='?', default=None)
 	args = parser.parse_args()
 
@@ -78,7 +83,7 @@ def main():
 				if stcl:
 					stcl.close()
 				stcl = starclass.get_classifier(current_classifier)
-				stcl = stcl(tset=tset, features_cache=None)
+				stcl = stcl(tset=tset, features_cache=None, truncate_lightcurves=args.truncate)
 
 			# ----------------- This code would run on each worker ------------------------
 

--- a/run_starclass_mpi.py
+++ b/run_starclass_mpi.py
@@ -44,6 +44,12 @@ def main():
 	parser.add_argument('--linfit', help='Enable linfit in training set.', action='store_true')
 	parser.add_argument('-l', '--level', help='Classification level', default='L1', choices=('L1', 'L2'))
 	#parser.add_argument('--datalevel', help="", default='corr', choices=('raw', 'corr')) # TODO: Come up with better name than "datalevel"?
+	# Lightcurve truncate override switch:
+	group = parser.add_mutually_exclusive_group(required=False)
+	group.add_argument('--truncate', dest='truncate', action='store_true', help='Force light curve truncation.')
+	group.add_argument('--no-truncate', dest='truncate', action='store_false', help='Force no light curve truncation.')
+	parser.set_defaults(truncate=None)
+	# Input folder:
 	parser.add_argument('input_folder', type=str, help='Input directory. This directory should contain a TODO-file and corresponding lightcurves.', nargs='?', default=None)
 	args = parser.parse_args()
 
@@ -164,7 +170,7 @@ def main():
 							if stcl:
 								stcl.close()
 							stcl = starclass.get_classifier(current_classifier)
-							stcl = stcl(tset=tset, features_cache=None)
+							stcl = stcl(tset=tset, features_cache=None, truncate_lightcurves=args.truncate)
 
 						fname = os.path.join(input_folder, task['lightcurve'])
 						features = stcl.load_star(task, fname)

--- a/starclass/BaseClassifier.py
+++ b/starclass/BaseClassifier.py
@@ -60,7 +60,8 @@ class BaseClassifier(object):
 	.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
 	"""
 
-	def __init__(self, tset=None, features_cache=None, plot=False, data_dir=None):
+	def __init__(self, tset=None, features_cache=None, plot=False, data_dir=None,
+		truncate_lightcurves=None):
 		"""
 		Initialize the classifier object.
 
@@ -72,6 +73,9 @@ class BaseClassifier(object):
 				saved/loaded as needed.
 			plot (bool, optional): Create plots as part of the output. Default is ``False``.
 			data_dir (str):
+			truncate_lightcurves (bool): Force truncation of lightcurves to 27.4 days.
+				If ``None``, the default will be decided based on the training-set
+				provided in ``tset``.
 
 		.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
 		"""
@@ -84,19 +88,24 @@ class BaseClassifier(object):
 		self.plot = plot
 		self.features_cache = features_cache
 		self._random_seed = 2187
+		self.truncate_lightcurves = truncate_lightcurves
 
 		# Inherit settings from the Training Set, just as a conveience:
 		if tset is None:
 			logger.warning("BaseClassifier initialized without TrainingSet")
 			self.StellarClasses = StellarClassesLevel1
 			self.linfit = False
-			self.truncate_lightcurves = False
 		else:
 			self.StellarClasses = tset.StellarClasses
 			self.linfit = tset.linfit
-			self.truncate_lightcurves = (not tset.key.startswith('keplerq9v3-long'))
 
-		logger.debug("Enable truncate lightcurves = %s", self.truncate_lightcurves)
+		# Decide if we should enable truncation of lightcurves upon loading:
+		if self.truncate_lightcurves is None:
+			if tset is None:
+				self.truncate_lightcurves = False
+			else:
+				self.truncate_lightcurves = (not tset.key.startswith('keplerq9v3-long'))
+		logger.debug("Truncate lightcurves = %s", self.truncate_lightcurves)
 
 		# Set the data directory, where results (trained models) will be saved:
 		if tset is not None:

--- a/starclass/BaseClassifier.py
+++ b/starclass/BaseClassifier.py
@@ -11,7 +11,7 @@ import numpy as np
 import os.path
 import logging
 from astropy.units import cds
-from lightkurve import TessLightCurve
+import lightkurve as lk
 from astropy.io import fits
 from tqdm import tqdm
 import enum
@@ -317,7 +317,7 @@ class BaseClassifier(object):
 				else:
 					quality = np.zeros(data.shape[0], dtype='int32')
 
-				lightcurve = TessLightCurve(
+				lightcurve = lk.TessLightCurve(
 					time=data[:,0],
 					flux=data[:,1],
 					flux_err=data[:,2],
@@ -332,28 +332,39 @@ class BaseClassifier(object):
 
 			elif fname.endswith(('.fits.gz', '.fits')):
 				with fits.open(fname, mode='readonly', memmap=True) as hdu:
-					lightcurve = TessLightCurve(
-						time=hdu['LIGHTCURVE'].data['TIME'],
-						flux=hdu['LIGHTCURVE'].data['FLUX_CORR'],
-						flux_err=hdu['LIGHTCURVE'].data['FLUX_CORR_ERR'],
-						flux_unit=cds.ppm,
-						centroid_col=hdu['LIGHTCURVE'].data['MOM_CENTR1'],
-						centroid_row=hdu['LIGHTCURVE'].data['MOM_CENTR2'],
-						quality=np.asarray(hdu['LIGHTCURVE'].data['QUALITY'], dtype='int32'),
-						cadenceno=np.asarray(hdu['LIGHTCURVE'].data['CADENCENO'], dtype='int32'),
-						time_format='btjd',
-						time_scale='tdb',
-						targetid=hdu[0].header.get('TICID'),
-						label=hdu[0].header.get('OBJECT'),
-						camera=hdu[0].header.get('CAMERA'),
-						ccd=hdu[0].header.get('CCD'),
-						sector=hdu[0].header.get('SECTOR'),
-						ra=hdu[0].header.get('RA_OBJ'),
-						dec=hdu[0].header.get('DEC_OBJ'),
-						quality_bitmask=1+2+256, # CorrectorQualityFlags.DEFAULT_BITMASK
-						meta={}
-					)
-
+					telescope = hdu[0].header.get('TELESCOP')
+					if telescope == 'TESS' and hdu[0].header.get('ORIGIN') == 'TASOC/Aarhus':
+						lightcurve = lk.TessLightCurve(
+							time=hdu['LIGHTCURVE'].data['TIME'],
+							flux=hdu['LIGHTCURVE'].data['FLUX_CORR'],
+							flux_err=hdu['LIGHTCURVE'].data['FLUX_CORR_ERR'],
+							flux_unit=cds.ppm,
+							centroid_col=hdu['LIGHTCURVE'].data['MOM_CENTR1'],
+							centroid_row=hdu['LIGHTCURVE'].data['MOM_CENTR2'],
+							quality=np.asarray(hdu['LIGHTCURVE'].data['QUALITY'], dtype='int32'),
+							cadenceno=np.asarray(hdu['LIGHTCURVE'].data['CADENCENO'], dtype='int32'),
+							time_format='btjd',
+							time_scale='tdb',
+							targetid=hdu[0].header.get('TICID'),
+							label=hdu[0].header.get('OBJECT'),
+							camera=hdu[0].header.get('CAMERA'),
+							ccd=hdu[0].header.get('CCD'),
+							sector=hdu[0].header.get('SECTOR'),
+							ra=hdu[0].header.get('RA_OBJ'),
+							dec=hdu[0].header.get('DEC_OBJ'),
+							quality_bitmask=1+2+256, # CorrectorQualityFlags.DEFAULT_BITMASK
+							meta={}
+						)
+					elif telescope == 'TESS':
+						lightcurve = lk.TESSLightCurveFile(hdu).PDCSAP_FLUX
+						lightcurve = 1e6 * (lightcurve.normalize() - 1)
+						lightcurve.flux_unit = cds.ppm
+					elif telescope == 'Kepler':
+						lightcurve = lk.KeplerLightCurveFile(hdu).PDCSAP_FLUX
+						lightcurve = 1e6 * (lightcurve.normalize() - 1)
+						lightcurve.flux_unit = cds.ppm
+					else:
+						raise ValueError("Could not determine FITS lightcurve type")
 			else:
 				raise ValueError("Invalid file format")
 

--- a/starclass/io.py
+++ b/starclass/io.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+
+
+.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
+"""
+
+import numpy as np
+from astropy.units import cds
+from astropy.io import fits
+import lightkurve as lk
+
+#--------------------------------------------------------------------------------------------------
+def load_lightcurve(fname, starid=None):
+
+	if fname.endswith(('.txt', '.noisy', '.sysnoise', '.clean')):
+		data = np.loadtxt(fname)
+		if data.shape[1] == 4:
+			quality = np.asarray(data[:,3], dtype='int32')
+		else:
+			quality = np.zeros(data.shape[0], dtype='int32')
+
+		lightcurve = lk.TessLightCurve(
+			time=data[:,0],
+			flux=data[:,1],
+			flux_err=data[:,2],
+			flux_unit=cds.ppm,
+			quality=quality,
+			time_format='jd',
+			time_scale='tdb',
+			targetid=starid,
+			quality_bitmask=2+8+256, # lightkurve.utils.TessQualityFlags.DEFAULT_BITMASK,
+			meta={}
+		)
+
+	elif fname.endswith(('.fits.gz', '.fits')):
+		with fits.open(fname, mode='readonly', memmap=True) as hdu:
+			telescope = hdu[0].header.get('TELESCOP')
+			if telescope == 'TESS' and hdu[0].header.get('ORIGIN') == 'TASOC/Aarhus':
+				lightcurve = lk.TessLightCurve(
+					time=hdu['LIGHTCURVE'].data['TIME'],
+					flux=hdu['LIGHTCURVE'].data['FLUX_CORR'],
+					flux_err=hdu['LIGHTCURVE'].data['FLUX_CORR_ERR'],
+					flux_unit=cds.ppm,
+					centroid_col=hdu['LIGHTCURVE'].data['MOM_CENTR1'],
+					centroid_row=hdu['LIGHTCURVE'].data['MOM_CENTR2'],
+					quality=np.asarray(hdu['LIGHTCURVE'].data['QUALITY'], dtype='int32'),
+					cadenceno=np.asarray(hdu['LIGHTCURVE'].data['CADENCENO'], dtype='int32'),
+					time_format='btjd',
+					time_scale='tdb',
+					targetid=hdu[0].header.get('TICID'),
+					label=hdu[0].header.get('OBJECT'),
+					camera=hdu[0].header.get('CAMERA'),
+					ccd=hdu[0].header.get('CCD'),
+					sector=hdu[0].header.get('SECTOR'),
+					ra=hdu[0].header.get('RA_OBJ'),
+					dec=hdu[0].header.get('DEC_OBJ'),
+					quality_bitmask=1+2+256, # CorrectorQualityFlags.DEFAULT_BITMASK
+					meta={}
+				)
+			elif telescope == 'TESS':
+				lightcurve = lk.TESSLightCurveFile(hdu).PDCSAP_FLUX
+				lightcurve = 1e6 * (lightcurve.normalize() - 1)
+				lightcurve.flux_unit = cds.ppm
+			elif telescope == 'Kepler':
+				lightcurve = lk.KeplerLightCurveFile(hdu).PDCSAP_FLUX
+				lightcurve = 1e6 * (lightcurve.normalize() - 1)
+				lightcurve.flux_unit = cds.ppm
+			else:
+				raise ValueError("Could not determine FITS lightcurve type")
+	else:
+		raise ValueError("Invalid file format")
+
+	return lightcurve

--- a/starclass/todolist.py
+++ b/starclass/todolist.py
@@ -15,14 +15,14 @@ from tqdm import tqdm
 from .io import load_lightcurve
 
 #--------------------------------------------------------------------------------------------------
-def create_fake_todolist(input_folder, output_todo='todo.sqlite', pattern=None,
+def create_fake_todolist(input_folder, name='todo.sqlite', pattern=None,
 	overwrite=False):
 	"""
 	Create todo-file by scanning directory for light curve files.
 
 	Parameters:
 		input_folder (str): Path to directory containing light curves to build todo-file from.
-		output_todo (str): Name of the todo-file which will be created in ``input_folder``.
+		name (str): Name of the todo-file which will be created in ``input_folder``.
 		pattern (str): Pattern to use for searching for light curve files in ``input_folder``.
 			The pattern must be a sting which can be interpreted by the ``fnmatch`` module.
 			The default is to match all FITS files (including compressed files).
@@ -40,10 +40,10 @@ def create_fake_todolist(input_folder, output_todo='todo.sqlite', pattern=None,
 	# Basic checks of the input:
 	if not os.path.isdir(input_folder):
 		raise NotADirectoryError(input_folder)
-	if not output_todo:
+	if not name:
 		raise ValueError("Invalid todo-file name")
-	if not output_todo.endswith('.sqlite'):
-		output_todo += '.sqlite'
+	if not name.endswith('.sqlite'):
+		name += '.sqlite'
 	if pattern:
 		file_pattern = fnmatch.translate(pattern)
 	else:
@@ -64,7 +64,7 @@ def create_fake_todolist(input_folder, output_todo='todo.sqlite', pattern=None,
 		raise ValueError("No files were found")
 
 	# Check path to the TODO-file, and delete if it already exists:
-	todo_file = os.path.join(input_folder, output_todo)
+	todo_file = os.path.join(input_folder, name)
 	if os.path.exists(todo_file):
 		if overwrite:
 			os.remove(todo_file)

--- a/starclass/todolist.py
+++ b/starclass/todolist.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+
+.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
+"""
+
+import os
+import re
+import sqlite3
+from contextlib import closing
+from .io import load_lightcurve
+
+#--------------------------------------------------------------------------------------------------
+def create_fake_todolist(input_folder, output_todo='todo.sqlite', file_pattern=None,
+	overwrite=False):
+	"""
+
+	.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
+	"""
+
+	# Basic checks of the input:
+	if not os.path.isdir(input_folder):
+		raise NotADirectoryError(input_folder)
+	if file_pattern is None:
+		file_pattern = r'\.fits(\.gz)?$'
+
+	# Go through the input directory recursively and find all files which match the pattern:
+	files = []
+	regex = re.compile(file_pattern)
+	for root, dirnames, filenames in os.walk(input_folder, followlinks=True):
+		for filename in filenames:
+			if regex.match(filename):
+				files.append(os.path.join(root, filename))
+
+	if not files:
+		raise ValueError("No files were found")
+
+	# Check path to the TODO-file, and delete if it already exists:
+	todo_file = os.path.join(input_folder, output_todo)
+	if os.path.exists(todo_file):
+		if overwrite:
+			os.remove(todo_file)
+		else:
+			raise ValueError()
+
+	# Open the todo-file and create the records of the files in it:
+	try:
+		with closing(sqlite3.connect(todo_file)) as conn:
+			cursor = conn.cursor()
+
+			todolist_structure(conn)
+
+			for k, fpath in enumerate(files):
+
+				lightcurve = os.path.relpath(fpath, input_folder).replace('\\', '/')
+
+				lc = load_lightcurve(fpath)
+				starid = lc.targetid
+
+				todolist_insert(cursor,
+					priority=k+1,
+					starid=starid,
+					lightcurve=lightcurve)
+
+	except: # noqa: E722, pragma: no cover
+		if os.path.exists(todo_file):
+			os.remove(todo_file)
+		raise
+
+	# Return to path of the created TODO-file:
+	return todo_file
+
+#--------------------------------------------------------------------------------------------------
+def todolist_structure(conn):
+	"""
+	Generate overall database structure for todo.sqlite.
+
+	Parameters:
+		conn (sqlite3.connection): Connection to SQLite file.
+
+	.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
+	"""
+
+	cursor = conn.cursor()
+	cursor.execute("PRAGMA foreign_keys=ON;")
+
+	cursor.execute("""CREATE TABLE todolist (
+		priority INTEGER PRIMARY KEY NOT NULL,
+		starid BIGINT NOT NULL,
+		datasource TEXT NOT NULL DEFAULT 'ffi',
+		camera INTEGER NOT NULL,
+		ccd INTEGER NOT NULL,
+		method TEXT DEFAULT NULL,
+		tmag REAL,
+		status INTEGER DEFAULT NULL,
+		corr_status INTEGER DEFAULT NULL,
+		cbv_area INTEGER NOT NULL
+	);""")
+	cursor.execute("CREATE INDEX status_idx ON todolist (status);")
+	cursor.execute("CREATE INDEX corr_status_idx ON todolist (corr_status);")
+	cursor.execute("CREATE INDEX starid_idx ON todolist (starid);")
+
+	cursor.execute("""CREATE TABLE diagnostics_corr (
+		priority INTEGER PRIMARY KEY NOT NULL,
+		lightcurve TEXT,
+		elaptime REAL,
+		worker_wait_time REAL,
+		variance REAL,
+		rms_hour REAL,
+		ptp REAL,
+		errors TEXT,
+		FOREIGN KEY (priority) REFERENCES todolist(priority) ON DELETE CASCADE ON UPDATE CASCADE
+	);""")
+
+	cursor.execute("""CREATE TABLE datavalidation_corr (
+		priority INTEGER PRIMARY KEY NOT NULL,
+		approved BOOLEAN NOT NULL,
+		dataval INTEGER NOT NULL,
+		FOREIGN KEY (priority) REFERENCES todolist(priority) ON DELETE CASCADE ON UPDATE CASCADE
+	);""")
+	cursor.execute("CREATE INDEX datavalidation_corr_approved_idx ON datavalidation_corr (approved);")
+
+	conn.commit()
+
+#--------------------------------------------------------------------------------------------------
+def todolist_insert(cursor, priority=None, lightcurve=None, starid=None,
+	tmag=None, datasource='ffi', variance=None, rms_hour=None, ptp=None, elaptime=None):
+	"""
+	Insert an entry in the todo.sqlite file.
+
+	Parameters:
+		cursor (sqlite3.Cursor): Cursor in SQLite file.
+		priority (int):
+		lightcurve (str):
+		starid (int):
+		tmag (float): TESS Magnitude.
+		datasource (str):
+		variance (float):
+		rms_hour (float):
+		ptp (float):
+		elaptime (float):
+
+	.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
+	"""
+
+	if priority is None:
+		raise ValueError("PRIORITY is required.")
+	if lightcurve is None:
+		raise ValueError("LIGHTCURVE is required.")
+	if starid is None:
+		starid = priority
+	if datasource not in ('ffi', 'tpf'):
+		raise ValueError("DATASOURCE should be FFI of TPF.")
+	if tmag is None:
+		tmag = -99
+
+	cursor.execute("INSERT INTO todolist (priority,starid,tmag,datasource,status,corr_status,camera,ccd,cbv_area) VALUES (?,?,?,?,1,1,1,1,111);", (
+		priority,
+		starid,
+		tmag,
+		datasource
+	))
+	cursor.execute("INSERT INTO diagnostics_corr (priority,lightcurve,elaptime,variance,rms_hour,ptp) VALUES (?,?,?,?,?,?);", (
+		priority,
+		lightcurve,
+		elaptime,
+		variance,
+		rms_hour,
+		ptp
+	))
+	cursor.execute("INSERT INTO datavalidation_corr (priority,approved,dataval) VALUES (?,1,0);", (priority,))

--- a/starclass/training_sets/tda_simulations.py
+++ b/starclass/training_sets/tda_simulations.py
@@ -13,6 +13,7 @@ import logging
 from tqdm import tqdm
 from ..StellarClasses import StellarClassesLevel1, StellarClassesLevel2
 from . import TrainingSet
+from ..todolist import todolist_structure, todolist_insert
 
 #--------------------------------------------------------------------------------------------------
 def _generate_todolist(self):
@@ -25,7 +26,7 @@ def _generate_todolist(self):
 		cursor = conn.cursor()
 
 		# Create the basic file structure of a TODO-list:
-		self.generate_todolist_structure(conn)
+		todolist_structure(conn)
 
 		logger.info("Step 3: Reading file and extracting information...")
 		starlist = np.genfromtxt(os.path.join(self.input_folder, 'Data_Batch_TDA4_r1.txt'),
@@ -56,7 +57,7 @@ def _generate_todolist(self):
 			variance, rms_hour, ptp = diagnostics[k]
 
 			pri += 1
-			self.generate_todolist_insert(cursor,
+			todolist_insert(cursor,
 				priority=pri,
 				starid=starid,
 				lightcurve=lightcurve,

--- a/starclass/training_sets/training_set.py
+++ b/starclass/training_sets/training_set.py
@@ -18,8 +18,9 @@ import sqlite3
 from contextlib import closing
 from tqdm import tqdm
 from sklearn.model_selection import train_test_split, StratifiedKFold
-from .. import BaseClassifier, TaskManager, utilities
+from .. import BaseClassifier, TaskManager, utilities, io
 from ..StellarClasses import StellarClassesLevel1, StellarClassesLevel2
+from ..todolist import todolist_structure, todolist_insert
 
 #--------------------------------------------------------------------------------------------------
 class TrainingSet(object):
@@ -270,13 +271,16 @@ class TrainingSet(object):
 				cursor = conn.cursor()
 
 				# Create the basic file structure of a TODO-list:
-				self.generate_todolist_structure(conn)
+				todolist_structure(conn)
 
 				logger.info("Step 3: Reading file and extracting information...")
 				pri = 0
 
-				diagnostics = np.genfromtxt(os.path.join(self.input_folder, 'diagnostics.txt'),
-					delimiter=',', comments='#', dtype=None, encoding='utf-8')
+				diagnostics_file = os.path.join(self.input_folder, 'diagnostics.txt')
+				diagnostics = None
+				if os.path.isfile(diagnostics_file):
+					diagnostics = np.genfromtxt(diagnostics_file,
+						delimiter=',', comments='#', dtype=None, encoding='utf-8')
 
 				for k, star in tqdm(enumerate(self.starlist), total=len(self.starlist)):
 					# Get starid:
@@ -298,17 +302,35 @@ class TrainingSet(object):
 						raise FileNotFoundError(lightcurve)
 
 					# Load diagnostics from file, to speed up the process:
-					variance, rms_hour, ptp = diagnostics[k]
+					if diagnostics is not None:
+						variance, rms_hour, ptp = diagnostics[k]
+					else:
+						# Try to load the lightcurve using the BaseClassifier method.
+						# This will ensure that the lightcurve can actually be read by the system.
+						lc = io.load_lightcurve(os.path.join(self.input_folder, lightcurve))
+
+						variance = nanvar(lc.flux, ddof=1)
+						rms_hour = utilities.rms_timescale(lc)
+						ptp = nanmedian(np.abs(np.diff(lc.flux)))
+
+						#if datasource is None:
+						#	if (lc.time[1] - lc.time[0])*86400 > 1000:
+						#		datasource = 'ffi'
+						#	else:
+						#		datasource = 'tpf'
+
+					elaptime = np.random.normal(3.14, 0.5)
 
 					pri += 1
-					self.generate_todolist_insert(cursor,
+					todolist_insert(cursor,
 						priority=pri,
 						starid=starid,
 						lightcurve=lightcurve,
 						datasource='ffi',
 						variance=variance,
 						rms_hour=rms_hour,
-						ptp=ptp)
+						ptp=ptp,
+						elaptime=elaptime)
 
 				conn.commit()
 				cursor.close()
@@ -319,144 +341,6 @@ class TrainingSet(object):
 			raise
 
 		logger.info("%s training set successfully built.", self.key)
-
-	#----------------------------------------------------------------------------------------------
-	def generate_todolist_structure(self, conn):
-		"""
-		Generate overall database structure for todo.sqlite.
-
-		Parameters:
-			conn (sqlite3.connection): Connection to SQLite file.
-
-		.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
-		"""
-
-		cursor = conn.cursor()
-		cursor.execute("PRAGMA foreign_keys=ON;")
-
-		cursor.execute("""CREATE TABLE todolist (
-			priority INTEGER PRIMARY KEY NOT NULL,
-			starid BIGINT NOT NULL,
-			datasource TEXT NOT NULL DEFAULT 'ffi',
-			camera INTEGER NOT NULL,
-			ccd INTEGER NOT NULL,
-			method TEXT DEFAULT NULL,
-			tmag REAL,
-			status INTEGER DEFAULT NULL,
-			corr_status INTEGER DEFAULT NULL,
-			cbv_area INTEGER NOT NULL
-		);""")
-		cursor.execute("CREATE INDEX status_idx ON todolist (status);")
-		cursor.execute("CREATE INDEX corr_status_idx ON todolist (corr_status);")
-		cursor.execute("CREATE INDEX starid_idx ON todolist (starid);")
-
-		cursor.execute("""CREATE TABLE diagnostics_corr (
-			priority INTEGER PRIMARY KEY NOT NULL,
-			lightcurve TEXT,
-			elaptime REAL,
-			worker_wait_time REAL,
-			variance REAL,
-			rms_hour REAL,
-			ptp REAL,
-			errors TEXT,
-			FOREIGN KEY (priority) REFERENCES todolist(priority) ON DELETE CASCADE ON UPDATE CASCADE
-		);""")
-
-		cursor.execute("""CREATE TABLE datavalidation_corr (
-			priority INTEGER PRIMARY KEY NOT NULL,
-			approved BOOLEAN NOT NULL,
-			dataval INTEGER NOT NULL,
-			FOREIGN KEY (priority) REFERENCES todolist(priority) ON DELETE CASCADE ON UPDATE CASCADE
-		);""")
-		cursor.execute("CREATE INDEX datavalidation_corr_approved_idx ON datavalidation_corr (approved);")
-
-		conn.commit()
-
-	#----------------------------------------------------------------------------------------------
-	def generate_todolist_insert(self, cursor, priority=None, lightcurve=None, starid=None,
-		tmag=None, datasource=None, variance=None, rms_hour=None, ptp=None):
-		"""
-		Insert an entry in the todo.sqlite file.
-
-		Parameters:
-			cursor (sqlite3.Cursor): Cursor in SQLite file.
-			priority (int):
-			lightcurve (str):
-			starid (int, optional):
-			tmag (float, optional): TESS Magnitude.
-			datasource (str, optional):
-			variance (float, optional):
-			rms_hour (float, optional):
-			ptp (float, optional):
-
-		.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
-		"""
-
-		if priority is None:
-			raise ValueError("PRIORITY is required.")
-		if lightcurve is None:
-			raise ValueError("LIGHTCURVE is required.")
-		if starid is None:
-			starid = priority
-
-		# Try to load the lightcurve using the BaseClassifier method.
-		# This will ensure that the lightcurve can actually be read by the system.
-		if not all([datasource, variance, rms_hour, ptp]):
-			with BaseClassifier(tset=self, features_cache=None) as bc:
-				# Most of the input is None, simply to silence warnings
-				fake_task = {
-					'priority': priority,
-					'starid': starid,
-					'tmag': None,
-					'variance': None,
-					'rms_hour': None,
-					'ptp': None,
-					'other_classifiers': None
-				}
-				features = bc.load_star(fake_task, os.path.join(self.input_folder, lightcurve))
-				lc = features['lightcurve']
-
-		elaptime = np.random.normal(3.14, 0.5)
-		if tmag is None:
-			tmag = -99
-		if variance is None:
-			variance = nanvar(lc.flux, ddof=1)
-		if rms_hour is None:
-			rms_hour = utilities.rms_timescale(lc)
-		if ptp is None:
-			ptp = nanmedian(np.abs(np.diff(lc.flux)))
-
-		if datasource is None:
-			if (lc.time[1] - lc.time[0])*86400 > 1000:
-				datasource = 'ffi'
-			else:
-				datasource = 'tpf'
-
-		#camera = 1
-		#if ecllat < 6+24:
-		#	camera = 1
-		#elif ecllat < 6+2*24:
-		#	camera = 2
-		#elif ecllat < 6+3*24:
-		#	camera = 3
-		#else:
-		#	camera = 4
-
-		cursor.execute("INSERT INTO todolist (priority,starid,tmag,datasource,status,corr_status,camera,ccd,cbv_area) VALUES (?,?,?,?,1,1,1,1,111);", (
-			priority,
-			starid,
-			tmag,
-			datasource
-		))
-		cursor.execute("INSERT INTO diagnostics_corr (priority,lightcurve,elaptime,variance,rms_hour,ptp) VALUES (?,?,?,?,?,?);", (
-			priority,
-			lightcurve,
-			elaptime,
-			variance,
-			rms_hour,
-			ptp
-		))
-		cursor.execute("INSERT INTO datavalidation_corr (priority,approved,dataval) VALUES (?,1,0);", (priority,))
 
 	#----------------------------------------------------------------------------------------------
 	def features(self):

--- a/starclass/training_sets/training_set.py
+++ b/starclass/training_sets/training_set.py
@@ -20,7 +20,7 @@ from tqdm import tqdm
 from sklearn.model_selection import train_test_split, StratifiedKFold
 from .. import BaseClassifier, TaskManager, utilities, io
 from ..StellarClasses import StellarClassesLevel1, StellarClassesLevel2
-from ..todolist import todolist_structure, todolist_insert
+from ..todolist import todolist_structure, todolist_insert, todolist_cleanup
 
 #--------------------------------------------------------------------------------------------------
 class TrainingSet(object):
@@ -337,6 +337,7 @@ class TrainingSet(object):
 						elaptime=elaptime)
 
 				conn.commit()
+				todolist_cleanup(conn, cursor)
 				cursor.close()
 
 		except: # noqa: E722, pragma: no cover

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,10 +11,33 @@ import os.path
 import tempfile
 import shutil
 import sys
+import subprocess
 
 # Insert starclass package as the first on path:
 if sys.path[0] != os.path.abspath(os.path.join(os.path.dirname(__file__), '..')):
 	sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+#--------------------------------------------------------------------------------------------------
+def capture_run_cli(cli, params):
+
+	if isinstance(params, str):
+		params = params.split()
+
+	cmd = [sys.executable, cli] + params
+	proc = subprocess.Popen(cmd,
+		cwd=os.path.join(os.path.dirname(__file__), '..'),
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE,
+		universal_newlines=True
+	)
+	out, err = proc.communicate()
+	exitcode = proc.returncode
+	proc.kill()
+
+	print("ExitCode: %d" % exitcode)
+	print("StdOut:\n%s" % out)
+	print("StdErr:\n%s" % err)
+	return out, err, exitcode
 
 #--------------------------------------------------------------------------------------------------
 @pytest.fixture(scope='session')

--- a/tests/input/create_todolist/kplr001864183-2012179063303_llc.fits.gz
+++ b/tests/input/create_todolist/kplr001864183-2012179063303_llc.fits.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf173bc722dc44f83fdb286b558a422516a1720463418e6ed2de3b8bf205ee35
+size 258705

--- a/tests/input/create_todolist/tess00029281992-s01-c1800-dr01-v04-tasoc-cbv_lc.fits.gz
+++ b/tests/input/create_todolist/tess00029281992-s01-c1800-dr01-v04-tasoc-cbv_lc.fits.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d299c90510def7f4ca5dd6510d798535bed23a57f33657850858c4090c75b5cf
+size 129046

--- a/tests/test_todolist.py
+++ b/tests/test_todolist.py
@@ -12,7 +12,7 @@ import tempfile
 import sqlite3
 from contextlib import closing
 import conftest # noqa: F401
-from starclass.todolist import todolist_structure, todolist_insert
+from starclass.todolist import todolist_structure, todolist_insert, create_fake_todolist
 
 #--------------------------------------------------------------------------------------------------
 def test_todolist_insert(SHARED_INPUT_DIR):
@@ -30,7 +30,7 @@ def test_todolist_insert(SHARED_INPUT_DIR):
 			with pytest.raises(ValueError):
 				todolist_insert(cursor, priority=1, lightcurve=None)
 
-			lightcurve = os.path.join(SHARED_INPUT_DIR, 'tess00029281992-s01-c1800-dr01-v04-tasoc-cbv_lc.fits.gz')
+			lightcurve = 'tess00029281992-s01-c1800-dr01-v04-tasoc-cbv_lc.fits.gz'
 			todolist_insert(cursor,
 				priority=2187,
 				starid=12345678,
@@ -93,3 +93,66 @@ def test_todolist_insert(SHARED_INPUT_DIR):
 			row = cursor.fetchone()
 			assert row['approved'] == 1 # These are constant!
 			assert row['dataval'] == 0 # These are constant!
+
+#--------------------------------------------------------------------------------------------------
+def test_todolist_create(PRIVATE_INPUT_DIR):
+
+	#
+	input_folder = os.path.join(PRIVATE_INPUT_DIR, 'create_todolist')
+	expected_file = os.path.join(input_folder, 'todo.sqlite')
+	assert not os.path.exists(expected_file)
+
+	todo_file = create_fake_todolist(input_folder)
+
+	# todo-file should now exist:
+	assert todo_file == expected_file
+	assert os.path.isfile(todo_file)
+
+	# Do a deep inspection of the todo-file:
+	with closing(sqlite3.connect('file:' + todo_file + '?mode=ro', uri=True)) as conn:
+		conn.row_factory = sqlite3.Row
+		cursor = conn.cursor()
+
+		cursor.execute("SELECT COUNT(*) FROM todolist;")
+		assert cursor.fetchone()[0] == 2
+
+		cursor.execute("SELECT COUNT(*) FROM diagnostics_corr;")
+		assert cursor.fetchone()[0] == 2
+
+		cursor.execute("SELECT COUNT(*) FROM datavalidation_corr;")
+		assert cursor.fetchone()[0] == 2
+
+		cursor.execute("SELECT lightcurve FROM diagnostics_corr;")
+		for row in cursor:
+			assert os.path.isfile(os.path.join(input_folder, row['lightcurve']))
+
+	# Running it again, without overwrite, should raise error:
+	with pytest.raises(ValueError) as e:
+		create_fake_todolist(input_folder)
+	assert str(e.value) == 'Todo-file already exists'
+
+	# Running it again with overwrite should suceed:
+	create_fake_todolist(input_folder, overwrite=True)
+
+#--------------------------------------------------------------------------------------------------
+def test_todolist_pattern(PRIVATE_INPUT_DIR):
+
+	input_folder = os.path.join(PRIVATE_INPUT_DIR, 'create_todolist')
+
+	# Using a pattern which will not match any targets should give an error:
+	with pytest.raises(ValueError) as e:
+		create_fake_todolist(input_folder, output_todo='todo-nomatch', pattern='*.txt')
+	assert str(e.value) == 'No files were found'
+
+	# Use pattern which only has a single match:
+	todo_file = create_fake_todolist(input_folder, output_todo='todo-single', pattern='tess*.fits.gz')
+
+	# Check that there is now only one target in the final list:
+	with closing(sqlite3.connect('file:' + todo_file + '?mode=ro', uri=True)) as conn:
+		cursor = conn.cursor()
+		cursor.execute("SELECT COUNT(*) FROM todolist;")
+		assert cursor.fetchone()[0] == 1
+
+#--------------------------------------------------------------------------------------------------
+if __name__ == '__main__':
+	pytest.main([__file__])

--- a/tests/test_todolist.py
+++ b/tests/test_todolist.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests of todolist generation.
+
+.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
+"""
+
+import pytest
+import os.path
+import tempfile
+import sqlite3
+from contextlib import closing
+import conftest # noqa: F401
+from starclass.todolist import todolist_structure, todolist_insert
+
+#--------------------------------------------------------------------------------------------------
+def test_todolist_insert(SHARED_INPUT_DIR):
+
+	with tempfile.TemporaryDirectory(prefix='pytest-private-tsets-') as tmpdir:
+		with closing(sqlite3.connect(os.path.join(tmpdir, 'todo.sqlite'))) as conn:
+			conn.row_factory = sqlite3.Row
+			cursor = conn.cursor()
+
+			todolist_structure(conn)
+
+			with pytest.raises(ValueError):
+				todolist_insert(cursor, priority=None)
+
+			with pytest.raises(ValueError):
+				todolist_insert(cursor, priority=1, lightcurve=None)
+
+			lightcurve = os.path.join(SHARED_INPUT_DIR, 'tess00029281992-s01-c1800-dr01-v04-tasoc-cbv_lc.fits.gz')
+			todolist_insert(cursor,
+				priority=2187,
+				starid=12345678,
+				tmag=15.6,
+				lightcurve=lightcurve,
+				datasource='tpf',
+				variance=3.14,
+				rms_hour=2.71,
+				ptp=42.0)
+
+			# TODOLIST table:
+			cursor.execute("SELECT * FROM todolist WHERE priority=2187;")
+			row = cursor.fetchone()
+			assert row['priority'] == 2187
+			assert row['starid'] == 12345678
+			assert row['tmag'] == 15.6
+			assert row['datasource'] == 'tpf'
+			assert row['camera'] == 1 # These are constant!
+			assert row['ccd'] == 1 # These are constant!
+			assert row['cbv_area'] == 111 # These are constant!
+			assert row['status'] == 1 # These are constant!
+			assert row['corr_status'] == 1 # These are constant!
+
+			# DIAGNOSTICS_CORR table:
+			cursor.execute("SELECT * FROM diagnostics_corr WHERE priority=2187;")
+			row = cursor.fetchone()
+			assert row['lightcurve'] == lightcurve
+			assert row['variance'] == 3.14
+			assert row['rms_hour'] == 2.71
+			assert row['ptp'] == 42.0
+
+			# DATAVALIDATION_CORR table:
+			cursor.execute("SELECT * FROM datavalidation_corr WHERE priority=2187;")
+			row = cursor.fetchone()
+			assert row['approved'] == 1 # These are constant!
+			assert row['dataval'] == 0 # These are constant!
+
+			todolist_insert(cursor,
+				priority=2188,
+				lightcurve=lightcurve)
+
+			# TODOLIST table:
+			cursor.execute("SELECT * FROM todolist WHERE priority=2188;")
+			row = cursor.fetchone()
+			assert row['priority'] == 2188
+			assert row['starid'] == 2188 # When not provided, will used priority
+			assert row['tmag'] == -99
+			assert row['datasource'] == 'ffi'
+
+			# DIAGNOSTICS_CORR table:
+			cursor.execute("SELECT * FROM diagnostics_corr WHERE priority=2188;")
+			row = cursor.fetchone()
+			assert row['lightcurve'] == lightcurve
+			assert row['variance'] is None
+			assert row['rms_hour'] is None
+			assert row['ptp'] is None
+
+			# DATAVALIDATION_CORR table:
+			cursor.execute("SELECT * FROM datavalidation_corr WHERE priority=2188;")
+			row = cursor.fetchone()
+			assert row['approved'] == 1 # These are constant!
+			assert row['dataval'] == 0 # These are constant!

--- a/tests/test_todolist.py
+++ b/tests/test_todolist.py
@@ -135,23 +135,33 @@ def test_todolist_create(PRIVATE_INPUT_DIR):
 	create_fake_todolist(input_folder, overwrite=True)
 
 #--------------------------------------------------------------------------------------------------
-def test_todolist_pattern(PRIVATE_INPUT_DIR):
+def test_todolist_create_pattern(PRIVATE_INPUT_DIR):
 
 	input_folder = os.path.join(PRIVATE_INPUT_DIR, 'create_todolist')
 
 	# Using a pattern which will not match any targets should give an error:
 	with pytest.raises(ValueError) as e:
-		create_fake_todolist(input_folder, output_todo='todo-nomatch', pattern='*.txt')
+		create_fake_todolist(input_folder, name='todo-nomatch', pattern='*.txt')
 	assert str(e.value) == 'No files were found'
 
 	# Use pattern which only has a single match:
-	todo_file = create_fake_todolist(input_folder, output_todo='todo-single', pattern='tess*.fits.gz')
+	todo_file = create_fake_todolist(input_folder, name='todo-single', pattern='tess*.fits.gz')
 
 	# Check that there is now only one target in the final list:
 	with closing(sqlite3.connect('file:' + todo_file + '?mode=ro', uri=True)) as conn:
 		cursor = conn.cursor()
 		cursor.execute("SELECT COUNT(*) FROM todolist;")
 		assert cursor.fetchone()[0] == 1
+
+#--------------------------------------------------------------------------------------------------
+def test_todolist_run_create(PRIVATE_INPUT_DIR):
+
+	# Private folder containing the file to build todo-file from:
+	input_folder = os.path.join(PRIVATE_INPUT_DIR, 'create_todolist')
+
+	# Run CLI version of create todolist program:
+	out, err, exitcode = conftest.capture_run_cli('run_create_todolist.py', input_folder)
+	assert exitcode == 0
 
 #--------------------------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/tests/test_todolist.py
+++ b/tests/test_todolist.py
@@ -30,6 +30,9 @@ def test_todolist_insert(SHARED_INPUT_DIR):
 			with pytest.raises(ValueError):
 				todolist_insert(cursor, priority=1, lightcurve=None)
 
+			with pytest.raises(ValueError):
+				todolist_insert(cursor, priority=1, lightcurve='doesntmatter.fits', datasource='invalid')
+
 			lightcurve = 'tess00029281992-s01-c1800-dr01-v04-tasoc-cbv_lc.fits.gz'
 			todolist_insert(cursor,
 				priority=2187,
@@ -102,6 +105,11 @@ def test_todolist_create(PRIVATE_INPUT_DIR):
 	expected_file = os.path.join(input_folder, 'todo.sqlite')
 	assert not os.path.exists(expected_file)
 
+	# Try calling with an non-existing folder should give an error:
+	with pytest.raises(NotADirectoryError):
+		create_fake_todolist(input_folder + '-does-not-exist')
+
+	# Now run it on the real folder containg files:
 	todo_file = create_fake_todolist(input_folder)
 
 	# todo-file should now exist:
@@ -138,6 +146,11 @@ def test_todolist_create(PRIVATE_INPUT_DIR):
 def test_todolist_create_pattern(PRIVATE_INPUT_DIR):
 
 	input_folder = os.path.join(PRIVATE_INPUT_DIR, 'create_todolist')
+
+	# Using a pattern which will not match any targets should give an error:
+	with pytest.raises(ValueError) as e:
+		create_fake_todolist(input_folder, name='')
+	assert str(e.value) == 'Invalid todo-file name'
 
 	# Using a pattern which will not match any targets should give an error:
 	with pytest.raises(ValueError) as e:


### PR DESCRIPTION
Enable creation of "fake" todo-files which will enable to run the code on light curves that doesn't have to come directly from the TASOC pipeline.

Things still missing:
- [x] Testing on wild real-world datasets. 
- [x] Unit-tests.
- [x] Automatic cutting out the first 27.4 days of data from Kepler/K2 data.
- [x] Switch to override automatic lightcurve truncation for testing?
